### PR TITLE
Changed data source for Node Table

### DIFF
--- a/check_nodes.py
+++ b/check_nodes.py
@@ -88,7 +88,7 @@ sys_from_nx = {
     "sys.gps.mode",
 }
 
-sys_from_dellblade = {
+sys_from_sbcore = {
     "sys.boot_time",
     # "sys.cooling",
     # "sys.cooling_max",
@@ -299,9 +299,9 @@ def main():
                 for name in raingauge_names - found:
                     results.append({"node": node, "vsn": vsn, "msg": f"missing raingauge {name}"})
         elif node in blade_nodes:
-            # check dellblade sys.*
+            # check blade sys.*
             found = set(df_node.loc[df_node["meta.host"].str.endswith("sb-core"), "name"])
-            for name in sys_from_dellblade - found:
+            for name in sys_from_sbcore - found:
                 results.append({"node": node, "vsn": vsn, "msg": f"missing sb-core {name}"})
 
     if args.ssh:

--- a/rollup_health_and_sanity_metrics.py
+++ b/rollup_health_and_sanity_metrics.py
@@ -299,13 +299,12 @@ def get_health_records_for_window(nodes, start, end, window):
         groups = df_vsn.groupby(["meta.task", "name"])
 
         def check_publishing_frequency_for_device(device, window):
-            if device in device_output_table:
-                for task, name, freq in device_output_table.get(device, []):
-                    try:
-                        group = groups.get_group((task, name))
-                        yield task, name, check_publishing_frequency(group, freq, window)
-                    except KeyError:
-                        yield task, name, 0.0
+            for task, name, freq in device_output_table.get(device, []):
+                try:
+                    group = groups.get_group((task, name))
+                    yield task, name, check_publishing_frequency(group, freq, window)
+                except KeyError:
+                    yield task, name, 0.0
 
         scheduled_tasks = scheduled_tasks_by_node.get(node.vsn, [])
 
@@ -334,13 +333,14 @@ def get_health_records_for_window(nodes, start, end, window):
         node_healthy = True
 
         for device in node.devices:
-            # the idea here is to translate the publishing frequency into a kind of SLA. here
-            # we're saying that after breaking the series up into window the size of the publishing
-            # frequency, we should see 1 sample per window in 90% of the windows.
-            healthy = check_publishing_sla_for_device(device, window, 0.90)
-            # accumulate full node health
-            node_healthy = node_healthy and healthy
-            add_device_health_check_record(node.vsn, device, healthy)
+            if device in device_output_table:
+                # the idea here is to translate the publishing frequency into a kind of SLA. here
+                # we're saying that after breaking the series up into window the size of the publishing
+                # frequency, we should see 1 sample per window in 90% of the windows.
+                healthy = check_publishing_sla_for_device(device, window, 0.90)
+                # accumulate full node health
+                node_healthy = node_healthy and healthy
+                add_device_health_check_record(node.vsn, device, healthy)
 
         add_node_health_check_record(node.vsn, node_healthy)
 

--- a/rollup_health_and_sanity_metrics.py
+++ b/rollup_health_and_sanity_metrics.py
@@ -289,7 +289,7 @@ def get_health_records_for_window(nodes, start, end, window):
 
     for node in nodes:
         try:
-            df_vsn = vsn_groups.get_group(node.vsn)
+            df_vsn = vsn_groups.get_group((node.vsn,))
         except:
             add_node_health_check_record(node.vsn, 0)
             for device in node.devices:

--- a/rollup_health_and_sanity_metrics.py
+++ b/rollup_health_and_sanity_metrics.py
@@ -14,9 +14,6 @@ from utils import (
     check_publishing_frequency,
 )
 
-#TODO: fix error, https://chatgpt.com/share/682bb9b4-1ddc-8003-b01e-92987d175253
-
-
 # these metrics are coming in inconsistently. we should debug later
 # but to make the health report less red, we'll comment them out.
 # sys.cooling*

--- a/rollup_health_and_sanity_metrics.py
+++ b/rollup_health_and_sanity_metrics.py
@@ -14,6 +14,8 @@ from utils import (
     check_publishing_frequency,
 )
 
+#TODO: fix error, https://chatgpt.com/share/682bb9b4-1ddc-8003-b01e-92987d175253
+
 
 # these metrics are coming in inconsistently. we should debug later
 # but to make the health report less red, we'll comment them out.
@@ -297,12 +299,13 @@ def get_health_records_for_window(nodes, start, end, window):
         groups = df_vsn.groupby(["meta.task", "name"])
 
         def check_publishing_frequency_for_device(device, window):
-            for task, name, freq in device_output_table[device]:
-                try:
-                    group = groups.get_group((task, name))
-                    yield task, name, check_publishing_frequency(group, freq, window)
-                except KeyError:
-                    yield task, name, 0.0
+            if device in device_output_table:
+                for task, name, freq in device_output_table.get(device, []):
+                    try:
+                        group = groups.get_group((task, name))
+                        yield task, name, check_publishing_frequency(group, freq, window)
+                    except KeyError:
+                        yield task, name, 0.0
 
         scheduled_tasks = scheduled_tasks_by_node.get(node.vsn, [])
 

--- a/rollup_health_and_sanity_metrics.py
+++ b/rollup_health_and_sanity_metrics.py
@@ -68,7 +68,7 @@ sys_from_nxcore = {
     # "sys.gps.mode",
 }
 
-sys_from_dellblade = {
+sys_from_sbcore = {
     "sys.boot_time",
     # "sys.cooling",
     # "sys.cooling_max",
@@ -194,7 +194,7 @@ device_output_table = {
     "nxcore": [("nxcore", name, "120s") for name in sys_from_nxcore],
     "nxagent": [("nxagent", name, "120s") for name in sys_from_nxagent],
     "rpi": [("rpi", name, "120s") for name in sys_from_rpi],
-    "dell": [("dell", name, "60s") for name in sys_from_dellblade],
+    "sbcore": [("sbcore", name, "60s") for name in sys_from_sbcore],
     "bme280": [("wes-iio-bme280", name, "30s") for name in outputs_from_bme],
     "bme680": [("wes-iio-bme680", name, "30s") for name in outputs_from_bme],
     "raingauge": [("wes-raingauge", name, "30s") for name in outputs_from_raingauge],
@@ -279,7 +279,7 @@ def get_health_records_for_window(nodes, start, end, window):
     # NOTE this will not really work for nodes with multiple rpis. we need to rethink this a bit
     # in the future. for now, we want to fix the urgent problem of differentiating most sys metrics.
     df.loc[is_sys & df["meta.host"].str.endswith("rpi"), "meta.task"] = "rpi"
-    df.loc[is_sys & df["meta.host"].str.endswith("sbcore"), "meta.task"] = "dell"
+    df.loc[is_sys & df["meta.host"].str.endswith("sbcore"), "meta.task"] = "sbcore"
 
     vsn_groups = df.groupby(["meta.vsn"])
 

--- a/rollup_health_and_sanity_metrics.py
+++ b/rollup_health_and_sanity_metrics.py
@@ -330,14 +330,15 @@ def get_health_records_for_window(nodes, start, end, window):
         node_healthy = True
 
         for device in node.devices:
-            if device in device_output_table:
-                # the idea here is to translate the publishing frequency into a kind of SLA. here
-                # we're saying that after breaking the series up into window the size of the publishing
-                # frequency, we should see 1 sample per window in 90% of the windows.
-                healthy = check_publishing_sla_for_device(device, window, 0.90)
-                # accumulate full node health
-                node_healthy = node_healthy and healthy
-                add_device_health_check_record(node.vsn, device, healthy)
+            # the idea here is to translate the publishing frequency into a kind of SLA. here
+            # we're saying that after breaking the series up into window the size of the publishing
+            # frequency, we should see 1 sample per window in 90% of the windows.
+            if device not in device_output_table:
+                 continue
+            healthy = check_publishing_sla_for_device(device, window, 0.90)
+            # accumulate full node health
+            node_healthy = node_healthy and healthy
+            add_device_health_check_record(node.vsn, device, healthy)
 
         add_node_health_check_record(node.vsn, node_healthy)
 

--- a/utils.py
+++ b/utils.py
@@ -57,6 +57,8 @@ def load_node_table_item(item):
     devices = set()
 
     # new config
+    #NOTE: all computes and sensors are added, but not all are used in the rollup
+    # since not all have a tests configured in health_and_sanity_metrics.py
     for compute in item["computes"]:
         devices.add(compute["name"].lower())
     for sensor in item["sensors"]:

--- a/utils.py
+++ b/utils.py
@@ -62,10 +62,6 @@ def load_node_table_item(item):
     for sensor in item["sensors"]:
         devices.add(sensor["name"].lower())
 
-    # TODO: blade compute in new api is sbcore not dell in devices and blade in node type
-    #   so I have to refactor the code or change the type and device name to dell if it's
-    #   too complicated to change the code to use sbcore not dell
-
     # TODO add camera stuff for upload checks
     return Node(
         id=item["name"].lower(),

--- a/utils.py
+++ b/utils.py
@@ -62,7 +62,6 @@ def load_node_table_item(item):
     for sensor in item["sensors"]:
         devices.add(sensor["name"].lower())
 
-    # TODO add camera stuff for upload checks
     return Node(
         id=item["name"].lower(),
         vsn=item["vsn"].upper(),

--- a/utils.py
+++ b/utils.py
@@ -47,35 +47,28 @@ class Node:
 
 
 def load_node_table():
-    r = requests.get("https://api.sagecontinuum.org/production")
+    r = requests.get("https://auth.sagecontinuum.org/api/v-beta/nodes/")
     r.raise_for_status()
     return [load_node_table_item(item) for item in r.json() if item["vsn"] != ""]
 
 
 def load_node_table_item(item):
-    node_type = item["node_type"].lower()
+    node_type = item["type"].lower()
     devices = set()
-    if node_type == "wsn":
-        devices.add("nxcore")
-        devices.add("bme280")
-    if node_type == "dell":
-        devices.add("dell")
-    if item["nx_agent"] is True:
-        devices.add("nxagent")
-    if item["shield"] is True:
-        devices.add("rpi")
-        devices.add("raingauge")
-        devices.add("bme680")
-        devices.add("microphone")
 
-    # add cameras
-    for dir in ["top", "bottom", "left", "right"]:
-        if item[f"{dir}_camera"] not in [None, "", "none"]:
-            devices.add(f"{dir}_camera")
+    # new config
+    for compute in item["computes"]:
+        devices.add(compute["name"].lower())
+    for sensor in item["sensors"]:
+        devices.add(sensor["name"].lower())
+
+    # TODO: blade compute in new api is sbcore not dell in devices and blade in node type
+    #   so I have to refactor the code or change the type and device name to dell if it's
+    #   too complicated to change the code to use sbcore not dell
 
     # TODO add camera stuff for upload checks
     return Node(
-        id=item["node_id"].lower(),
+        id=item["name"].lower(),
         vsn=item["vsn"].upper(),
         type=node_type,
         devices=devices,


### PR DESCRIPTION
This pull request includes several updates to standardize terminology and refactor code for improved consistency and maintainability. The most notable changes involve replacing references to "dellblade" with "sbcore" and updating the node table parsing logic to align with a new API structure.

### Node table refactoring:
* Modified the `load_node_table` function in `utils.py` to use a new API endpoint (`https://auth.sagecontinuum.org/api/v-beta/nodes/`) and updated the parsing logic to accommodate the new API structure.
* Refactored `load_node_table_item` to dynamically populate devices based on the `computes` and `sensors` fields in the API response, replacing the previous hardcoded logic.

### Terminology standardization:
* Replaced all occurrences of `sys_from_dellblade` with `sys_from_sbcore` across `check_nodes.py` and `rollup_health_and_sanity_metrics.py` for consistency with updated naming conventions. [[1]](diffhunk://#diff-3e1fa2ed4a81d010368e5dd623d2f2f92fdc8343489b7aaaf9303a129d1f87d2L91-R91) [[2]](diffhunk://#diff-100e0297b0c620d13b98c1097d50bdf3694c92d61bde4a71004562134ff8ce0cL71-R71)
* Updated comments and logic to reflect the change from "dellblade" to "sbcore" in relevant sections of `check_nodes.py` and `rollup_health_and_sanity_metrics.py`. [[1]](diffhunk://#diff-3e1fa2ed4a81d010368e5dd623d2f2f92fdc8343489b7aaaf9303a129d1f87d2L302-R304) [[2]](diffhunk://#diff-100e0297b0c620d13b98c1097d50bdf3694c92d61bde4a71004562134ff8ce0cL197-R197) [[3]](diffhunk://#diff-100e0297b0c620d13b98c1097d50bdf3694c92d61bde4a71004562134ff8ce0cL282-R282)